### PR TITLE
Begin feature to ping groups

### DIFF
--- a/server/db/relationshipModel.js
+++ b/server/db/relationshipModel.js
@@ -1,10 +1,13 @@
 var db = require('../db/index.js');
 var Group = require('../groups/groupModel.js');
 var User = require('../users/userModel.js');
+var Sequelize = require('sequelize');
 
-var Memberships = db.define('Memberships', {});
+var Membership = db.define('Memberships', {
+  active: {type: Sequelize.BOOLEAN, defaultValue: true}
+});
 
-User.belongsToMany(Group, {through: 'Memberships'});
-Group.belongsToMany(User, {through: 'Memberships'});
+User.belongsToMany(Group, {through: Membership});
+Group.belongsToMany(User, {through: Membership});
 
-Memberships.sync();
+Membership.sync();

--- a/server/groups/groupController.js
+++ b/server/groups/groupController.js
@@ -14,20 +14,24 @@ module.exports = {
     });
   },
 
-  create: function (req, res) {
-    Group.sync().then(function () {
-      var group = Group.build(req.body);
-      group.save()
-      .then(function (result) {
-        res.end(JSON.stringify(result));
-      })
-    });
-  },
-
   browse: function (req, res) {
     Group.findAll()
     .then(function (groups) {
       res.end(JSON.stringify(groups));
+    });
+  },
+
+  create: function (req, res) {
+    Group.build(req.body).save()
+    .then(function (result) {
+      res.end(JSON.stringify(result));
+    });
+  },
+
+  members: function (req, res) {
+    req.group.getUsers()
+    .then(function (users) {
+      res.end(JSON.stringify(users));
     });
   },
 
@@ -45,11 +49,8 @@ module.exports = {
     });
   },
 
-  members: function (req, res) {
-    req.group.getUsers()
-    .then(function (users) {
-      res.end(JSON.stringify(users));
-    });
+  history: function (req, res) {
+
   },
 
   ping: function (req, res) {

--- a/server/groups/groupController.js
+++ b/server/groups/groupController.js
@@ -8,7 +8,7 @@ module.exports = {
       if (!group) {
         console.log('user is searching for "' + groupName + '", but not in database');
       } else {
-        req.groupId = group.id;
+        req.group = group;
         next();
       }
     });
@@ -35,17 +35,30 @@ module.exports = {
     // TODO: security concern that username is coming from POST request. Easy to forge
     require('../users/userModel.js').findOne({where: {username: req.body.username}})
     .then(function (user) {
-      user.addGroup(req.groupId)
+      user.addGroup(req.group.id)
       .then(function (result) {
         res.end(JSON.stringify(result));
       })
-      .error(function (err) {
+      .catch(function (err) {
         console.log(err);
       });
     });
   },
 
-  ping: function (req, res) {
+  members: function (req, res) {
+    req.group.getUsers()
+    .then(function (users) {
+      res.end(JSON.stringify(users));
+    });
+  },
 
+  ping: function (req, res) {
+    req.group.getUsers()
+    .then(function (users) {
+      users.forEach(function (user) {
+
+      })
+      res.end('Pinged ' + users.length + 'members of ' + req.group.name);
+    });
   }
 };

--- a/server/groups/groupRoutes.js
+++ b/server/groups/groupRoutes.js
@@ -11,5 +11,6 @@ module.exports = function (app) {
   app.get('/', groupController.browse);
 
   app.post('/:group', groupController.join);
+  app.get('/:group', groupController.members);
   app.post('/:group/pings/', groupController.ping);
 };

--- a/server/groups/groupRoutes.js
+++ b/server/groups/groupRoutes.js
@@ -7,10 +7,12 @@ module.exports = function (app) {
 
   app.param('group', groupController.findGroup);
 
-  app.post('/', groupController.create);
   app.get('/', groupController.browse);
+  app.post('/', groupController.create);
 
-  app.post('/:group', groupController.join);
   app.get('/:group', groupController.members);
+  app.post('/:group', groupController.join);
+
+  app.get('/:group/pings/', groupController.history);
   app.post('/:group/pings/', groupController.ping);
 };


### PR DESCRIPTION
This pull request adds a Group.members() method and route **GET api/groups/:group**, which lists all the members of a particular group.

It adds the code for pinging group members, except for calling the client libraries to send the pings.

It adds a placeholder method for .history(), (**GET /api/groups/:group/pings**) to view the history of pings to a particular group.

And it adds an `active` boolean to the memberships table, which defaults to true.
