### PR TITLE
Fix ping from ng-client

### DIFF
--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -45,7 +45,7 @@ angular.module('boundless.services', [])
 		console.log(data.username + ' pinged the group: ' + data.name);
 		return $http({
 			method: 'POST',
-			url: '/api/' + data.name + '/pings/',
+			url: '/api/groups/' + data.name + '/pings/',
 			data: {username: data.username}
 		})
 		.then(function(resp) {

--- a/server/users/userController.js
+++ b/server/users/userController.js
@@ -5,6 +5,20 @@ var utils = require('../config/utils');
 
 
 module.exports = {
+  findByUsername: function (username, callback) {
+    User.findOne({where: {username: username}})
+    .then(function (user) {
+      if (!user) {
+        console.log('No user with username ' + username + ' in database');
+      } else {
+        if (callback) {
+          callback(user);
+        } else {
+          return user;
+        }
+      }
+    });
+  },
   findByPhone: function (phone, callback) {
     User.findOne({where: {phone: phone}})
     .then(function (user) {


### PR DESCRIPTION
This pull request fixes ping'ing from the angular client.

It changes the REST api a tad by now expecting the `api/groups/:group/pings` POST body to be:
`{username: [pinger's username]}`

If a `req.user` has already been set, e.g. in the case of Twilio, it manually sets that username to `req.body.username` to preserve compatibility.
