### PR TITLE
Auto-join newly created groups

### DIFF
--- a/server/groups/groupController.js
+++ b/server/groups/groupController.js
@@ -34,9 +34,18 @@ module.exports = {
   },
 
   create: function (req, res) {
-    Group.build(req.body).save()
+    var newGroup = Group.build(req.body);
+    newGroup.save()
     .then(function (result) {
-      res.end(JSON.stringify(result));
+      if (req.body.username) {
+        require('../users/userController.js').findByUsername(req.body.username, function(user) {
+          user.addGroup(newGroup).then(function (result) {
+            res.end(JSON.stringify(result));
+          });
+        });
+      } else {
+        res.end(JSON.stringify(result));
+      }
     });
   },
 


### PR DESCRIPTION
Added auto-join of newly created groups

Works the same as before if no `{username: }` key is passed in req.body.
